### PR TITLE
refactor: Standardize Gradle configuration using convention plugins a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ local.properties
 data/build
 domain/build
 presentation/build
-
+build-logic/build
+.kotlin
 .idea

--- a/README.md
+++ b/README.md
@@ -1,1 +1,192 @@
-# book-search
+# 📚 Book Search
+
+안드로이드 책 검색 앱으로, 카카오 책 검색 API를 활용하여 도서를 검색하고 즐겨찾기 기능을 제공합니다.
+
+## 🚀 주요 기능
+
+- **도서 검색**: 제목, 저자명으로 도서 검색
+- **정렬 기능**: 정확도순, 발간일순 정렬
+- **필터링**: 가격대, 출판사별 필터링
+- **즐겨찾기**: 관심 있는 도서를 즐겨찾기에 추가/제거
+- **상세 정보**: 도서의 상세 정보 확인
+- **무한 스크롤**: 검색 결과 페이지네이션
+
+## 🛠 기술 스택
+
+### 프레임워크 & 라이브러리
+- **언어**: Kotlin
+- **UI**: Jetpack Compose
+- **아키텍처**: Clean Architecture (MVVM)
+- **의존성 주입**: Service Locator 패턴
+- **네트워킹**: Ktor Client
+- **로컬 데이터베이스**: Room
+- **이미지 로딩**: Coil
+- **네비게이션**: Navigation Compose
+- **비동기 처리**: Kotlin Coroutines + Flow
+
+### 개발 도구
+- **빌드 도구**: Gradle (Kotlin DSL)
+- **버전 관리**: Version Catalog
+- **코드 생성**: KSP (Kotlin Symbol Processing)
+
+## 📁 프로젝트 구조
+
+```
+book-search/
+├── app/                    # 애플리케이션 모듈
+│   ├── src/main/java/
+│   │   ├── MainActivity.kt
+│   │   ├── ServiceLocator.kt
+│   │   └── ui/theme/       # 테마 관련 파일들
+│   └── build.gradle.kts
+├── domain/                 # 도메인 모듈 (비즈니스 로직)
+│   └── src/main/kotlin/
+│       └── com/mygomii/booksearch/domain/
+│           ├── model/      # 도메인 모델
+│           ├── repository/ # 리포지토리 인터페이스
+│           └── usecase/    # 유스케이스
+├── data/                   # 데이터 모듈 (데이터 소스)
+│   └── src/main/java/
+│       └── com/mygomii/booksearch/data/
+│           ├── local/      # Room 데이터베이스
+│           ├── remote/     # API 클라이언트
+│           ├── mapper/     # DTO ↔ Domain 변환
+│           └── repository/ # 리포지토리 구현체
+├── presentation/           # 프레젠테이션 모듈 (UI)
+│   └── src/main/java/
+│       └── com/mygomii/booksearch/presentation/
+│           ├── search/     # 검색 화면
+│           ├── favorites/  # 즐겨찾기 화면
+│           ├── detail/     # 상세 화면
+│           ├── navigation/ # 네비게이션
+│           └── util/       # 유틸리티
+└── gradle/
+    └── libs.versions.toml  # 의존성 버전 관리
+```
+
+## 🏗 아키텍처
+
+### Clean Architecture 적용
+```
+┌─────────────────┐
+│   Presentation  │ ← UI Layer (Compose + ViewModel)
+├─────────────────┤
+│     Domain      │ ← Business Logic Layer
+├─────────────────┤
+│      Data       │ ← Data Layer (Repository + DataSource)
+└─────────────────┘
+```
+
+### 모듈 의존성
+- `app` → `presentation` → `domain` ← `data`
+- 각 모듈은 단방향 의존성을 유지
+- 도메인 모듈은 외부 의존성 없음
+
+## 🔧 빌드 방법
+
+### 사전 요구사항
+- Android Studio Hedgehog (2023.1.1) 이상
+- JDK 17 이상
+- Android SDK API 24 이상
+
+### 1. 저장소 클론
+```bash
+git clone https://github.com/your-username/book-search.git
+cd book-search
+```
+
+### 2. API 키 설정
+`local.properties` 파일을 생성하고 카카오 API 키를 추가합니다:
+
+```properties
+KAKAO_API_KEY=your_kakao_api_key_here
+```
+
+카카오 API 키 발급 방법:
+1. [카카오 개발자 콘솔](https://developers.kakao.com/) 접속
+2. 애플리케이션 등록
+3. REST API 키 복사
+
+### 3. 프로젝트 빌드
+```bash
+# Debug 빌드
+./gradlew assembleDebug
+
+# Release 빌드
+./gradlew assembleRelease
+```
+
+### 4. 앱 실행
+```bash
+# 디바이스에 설치 및 실행
+./gradlew installDebug
+```
+
+## 📱 주요 구현 포인트
+
+### 1. Clean Architecture
+- **Domain Layer**: 비즈니스 로직과 엔티티 정의
+- **Data Layer**: Repository 패턴으로 데이터 소스 추상화
+- **Presentation Layer**: Compose + ViewModel로 UI 상태 관리
+
+### 2. 상태 관리
+```kotlin
+data class SearchUiState(
+    val query: String = "",
+    val sort: SortType = SortType.ACCURACY,
+    val items: List<Book> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val favoriteIsbns: Set<String> = emptySet()
+)
+```
+
+### 3. 네트워킹
+- **Ktor Client**: HTTP 클라이언트
+- **Kotlinx Serialization**: JSON 직렬화/역직렬화
+- **에러 핸들링**: `runCatching`으로 안전한 네트워크 호출
+
+### 4. 로컬 데이터베이스
+- **Room**: SQLite 추상화
+- **Flow**: 실시간 데이터 관찰
+- **마이그레이션**: 스키마 변경 대응
+
+### 5. UI/UX
+- **Material 3**: 최신 디자인 시스템
+- **반응형 UI**: 다양한 화면 크기 대응
+- **로딩 상태**: 사용자 경험 개선
+
+## 🔄 데이터 흐름
+
+1. **검색 요청**: 사용자가 검색어 입력
+2. **ViewModel**: UI 상태 업데이트 및 UseCase 호출
+3. **UseCase**: 비즈니스 로직 처리
+4. **Repository**: 데이터 소스 선택 (API 또는 로컬 DB)
+5. **API 호출**: 카카오 책 검색 API 요청
+6. **데이터 변환**: DTO → Domain 모델 변환
+7. **UI 업데이트**: Compose 리컴포지션
+
+## 🧪 테스트
+
+```bash
+# Unit 테스트 실행
+./gradlew test
+
+# Instrumented 테스트 실행
+./gradlew connectedAndroidTest
+```
+
+## 📦 의존성 관리
+
+Version Catalog를 사용하여 의존성을 중앙 집중식으로 관리:
+
+```toml
+[versions]
+kotlin = "2.0.21"
+composeBom = "2024.09.00"
+ktor = "2.3.12"
+room = "2.6.1"
+
+[libraries]
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,7 @@
 import java.util.Properties
 
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)
+    id("com.mygomii.android.application")
 }
 
 android {
@@ -12,8 +10,6 @@ android {
 
     defaultConfig {
         applicationId = "com.mygomii.book_search"
-        minSdk = 24
-        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 
@@ -29,20 +25,9 @@ android {
             )
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-    buildFeatures {
-        compose = true
-        buildConfig = true
-    }
+    buildFeatures { buildConfig = true }
 }
 
-// Inject Kakao API key from local.properties into BuildConfig
 val kakaoKey: String = run {
     val props = Properties()
     val f = rootProject.file("local.properties")
@@ -60,10 +45,7 @@ dependencies {
     implementation(project(":data"))
     implementation(project(":presentation"))
 
-    // Needed for ServiceLocator (Room databaseBuilder)
     implementation(libs.androidx.room.runtime)
-    // Ktor types are exposed by :data via api, but adding is harmless if needed
-
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    `kotlin-dsl`
+}
+
+group = "com.mygomii.buildlogic"
+
+gradlePlugin {
+    plugins {
+        register("androidApplicationConvention") {
+            id = "com.mygomii.android.application"
+            implementationClass = "AndroidApplicationConventionPlugin"
+        }
+        register("androidLibraryConvention") {
+            id = "com.mygomii.android.library"
+            implementationClass = "AndroidLibraryConventionPlugin"
+        }
+        register("kotlinLibraryConvention") {
+            id = "com.mygomii.kotlin.library"
+            implementationClass = "KotlinLibraryConventionPlugin"
+        }
+    }
+}
+
+dependencies {
+    implementation("com.android.tools.build:gradle:${libs.versions.agp.get()}")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}")
+}
+

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,23 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"

--- a/build-logic/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -1,0 +1,41 @@
+import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+class AndroidApplicationConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("com.android.application")
+            pluginManager.apply("org.jetbrains.kotlin.android")
+            pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
+
+        extensions.configure<ApplicationExtension> {
+            compileSdk = 36
+
+            defaultConfig {
+                minSdk = 24
+                targetSdk = 36
+            }
+
+            buildFeatures {
+                compose = true
+                buildConfig = true
+            }
+
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+        }
+
+        project.extensions.findByName("kotlin")?.let {
+            try {
+                val kts = it as org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+                kts.jvmToolchain(17)
+            } catch (_: Throwable) {}
+        }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -1,0 +1,34 @@
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+class AndroidLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("com.android.library")
+            pluginManager.apply("org.jetbrains.kotlin.android")
+
+        extensions.configure<LibraryExtension> {
+            compileSdk = 36
+
+            defaultConfig {
+                minSdk = 24
+            }
+
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+        }
+
+        project.extensions.findByName("kotlin")?.let {
+            try {
+                val kts = it as org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+                kts.jvmToolchain(17)
+            } catch (_: Throwable) {}
+        }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/KotlinLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/KotlinLibraryConventionPlugin.kt
@@ -1,0 +1,14 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+class KotlinLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("org.jetbrains.kotlin.jvm")
+
+        project.extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension> {
+            jvmToolchain(17)
+        }
+    }
+}
+

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
-    id("com.android.library")
-    alias(libs.plugins.kotlin.android)
+    id("com.mygomii.android.library")
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
 }
@@ -8,18 +7,6 @@ plugins {
 android {
     namespace = "com.mygomii.booksearch.data"
     compileSdk = 36
-
-    defaultConfig {
-        minSdk = 24
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
 }
 
 dependencies {
@@ -27,16 +14,12 @@ dependencies {
 
     implementation(libs.kotlinx.coroutines.core)
 
-    // Ktor (exposed because KakaoBookApi public API references HttpClient)
     api(libs.ktor.client.android)
     api(libs.ktor.client.content.negotiation)
     api(libs.ktor.serialization.kotlinx.json)
     api(libs.ktor.client.logging)
 
-    // Room
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
-
-    // Kotlinx Serialization is brought by plugin
 }

--- a/domain/bin/main/com/mygomii/booksearch/domain/model/Book.kt
+++ b/domain/bin/main/com/mygomii/booksearch/domain/model/Book.kt
@@ -1,0 +1,15 @@
+package com.mygomii.booksearch.domain.model
+
+data class Book(
+    val title: String,
+    val authors: List<String>,
+    val publisher: String?,
+    val datetime: String?,
+    val price: Int?,
+    val salePrice: Int?,
+    val thumbnail: String?,
+    val isbn: String?,
+    val url: String?,
+    val contents: String?,
+    val addedAt: Long? = null
+)

--- a/domain/bin/main/com/mygomii/booksearch/domain/model/PagedBooks.kt
+++ b/domain/bin/main/com/mygomii/booksearch/domain/model/PagedBooks.kt
@@ -1,0 +1,9 @@
+package com.mygomii.booksearch.domain.model
+
+data class PagedBooks(
+    val items: List<Book>,
+    val isEnd: Boolean,
+    val totalCount: Int,
+    val pageableCount: Int
+)
+

--- a/domain/bin/main/com/mygomii/booksearch/domain/model/SortType.kt
+++ b/domain/bin/main/com/mygomii/booksearch/domain/model/SortType.kt
@@ -1,0 +1,7 @@
+package com.mygomii.booksearch.domain.model
+
+enum class SortType(val apiValue: String) {
+    ACCURACY("accuracy"),
+    RECENCY("recency")
+}
+

--- a/domain/bin/main/com/mygomii/booksearch/domain/repository/BookRepository.kt
+++ b/domain/bin/main/com/mygomii/booksearch/domain/repository/BookRepository.kt
@@ -1,0 +1,20 @@
+package com.mygomii.booksearch.domain.repository
+
+import com.mygomii.booksearch.domain.model.Book
+import com.mygomii.booksearch.domain.model.PagedBooks
+import com.mygomii.booksearch.domain.model.SortType
+import kotlinx.coroutines.flow.Flow
+
+interface BookRepository {
+    suspend fun searchBooks(
+        query: String,
+        sort: SortType,
+        page: Int,
+        size: Int
+    ): PagedBooks
+
+    fun observeFavorites(): Flow<List<Book>>
+    suspend fun toggleFavorite(book: Book)
+    suspend fun isFavorite(isbn: String): Boolean
+}
+

--- a/domain/bin/main/com/mygomii/booksearch/domain/usecase/ObserveFavoritesUseCase.kt
+++ b/domain/bin/main/com/mygomii/booksearch/domain/usecase/ObserveFavoritesUseCase.kt
@@ -1,0 +1,10 @@
+package com.mygomii.booksearch.domain.usecase
+
+import com.mygomii.booksearch.domain.model.Book
+import com.mygomii.booksearch.domain.repository.BookRepository
+import kotlinx.coroutines.flow.Flow
+
+class ObserveFavoritesUseCase(private val repository: BookRepository) {
+    operator fun invoke(): Flow<List<Book>> = repository.observeFavorites()
+}
+

--- a/domain/bin/main/com/mygomii/booksearch/domain/usecase/SearchBooksUseCase.kt
+++ b/domain/bin/main/com/mygomii/booksearch/domain/usecase/SearchBooksUseCase.kt
@@ -1,0 +1,12 @@
+package com.mygomii.booksearch.domain.usecase
+
+import com.mygomii.booksearch.domain.model.PagedBooks
+import com.mygomii.booksearch.domain.model.SortType
+import com.mygomii.booksearch.domain.repository.BookRepository
+
+class SearchBooksUseCase(private val repository: BookRepository) {
+    suspend operator fun invoke(query: String, sort: SortType, page: Int, size: Int): PagedBooks {
+        return repository.searchBooks(query, sort, page, size)
+    }
+}
+

--- a/domain/bin/main/com/mygomii/booksearch/domain/usecase/ToggleFavoriteUseCase.kt
+++ b/domain/bin/main/com/mygomii/booksearch/domain/usecase/ToggleFavoriteUseCase.kt
@@ -1,0 +1,9 @@
+package com.mygomii.booksearch.domain.usecase
+
+import com.mygomii.booksearch.domain.model.Book
+import com.mygomii.booksearch.domain.repository.BookRepository
+
+class ToggleFavoriteUseCase(private val repository: BookRepository) {
+    suspend operator fun invoke(book: Book) = repository.toggleFavorite(book)
+}
+

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,15 +1,5 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-}
-
-kotlin {
-    jvmToolchain(17)
+    id("com.mygomii.kotlin.library")
 }
 
 dependencies {

--- a/example.md
+++ b/example.md
@@ -1,0 +1,122 @@
+# Book Search App – README
+
+## 개요
+- 카카오 도서 검색 API 기반의 안드로이드 샘플 앱입니다.
+- Clean Architecture + 멀티 모듈 구성: `app`, `domain`, `data`, `presentation`, `build-logic`.
+- UI는 Jetpack Compose, 네트워크는 Ktor, 로컬 저장은 Room을 사용합니다.
+
+## 사용 프레임워크/라이브러리
+- 언어/코어: Kotlin, Coroutines, Flow
+- UI: Jetpack Compose (Material3, Navigation, Icons), Coil(이미지)
+- 네트워크: Ktor Client + Kotlinx Serialization(Json)
+- 로컬: Room (즐겨찾기 보관)
+- 구조: Clean Architecture (Domain/Data/Presentation), 멀티모듈
+- Gradle: AGP 8.13.0, Kotlin 2.0.21, Compose BOM 2024.09.00
+- 빌드 로직: `build-logic`(Convention Plugins)
+
+## 빌드/실행 방법
+1) JDK 17 사용
+- Android Studio에서 Gradle JDK 17 설정 (Gradle 8.x + AGP 8.x 호환)
+
+2) Kakao API 키 설정
+- `local.properties` 파일에 아래 항목 추가 (또는 환경변수 `KAKAO_API_KEY` 설정)
+```
+KAKAO_API_KEY=카카오_레스트_API_키
+```
+
+3) Gradle 빌드/설치
+```
+./gradlew :app:assembleDebug
+./gradlew :app:installDebug
+```
+- 최초 실행 시 검색 화면이 열리며 자동으로 ‘미움받을 용기’로 검색됩니다.
+
+## 프로젝트 구조
+```
+book-search/
+├─ app/                      # Application 모듈(Entry, ServiceLocator, AndroidManifest)
+├─ domain/                   # 순수 Kotlin: 모델, Repository 인터페이스, UseCase
+│  ├─ model/                 # Book, PagedBooks, SortType
+│  ├─ repository/            # BookRepository
+│  └─ usecase/               # SearchBooks/ToggleFavorite/ObserveFavorites
+├─ data/                     # 구현체: 원격(Ktor), 로컬(Room), Repository Impl
+│  ├─ remote/                # KakaoBookApi, DTOs, mappers
+│  ├─ local/                 # Room(AppDatabase, Dao, Entity)
+│  └─ repository/            # BookRepositoryImpl
+├─ presentation/             # Compose UI, ViewModel, Navigation
+│  ├─ search/                # 검색 화면 + VM
+│  ├─ favorites/             # 즐겨찾기 화면 + VM
+│  ├─ detail/                # 상세 화면
+│  ├─ navigation/            # 라우트 정의
+│  └─ util/                  # UI 유틸(가격 포맷 등)
+├─ build-logic/              # Gradle Convention Plugins
+│  ├─ AndroidApplicationConventionPlugin.kt (id: com.mygomii.android.application)
+│  ├─ AndroidLibraryConventionPlugin.kt     (id: com.mygomii.android.library)
+│  └─ KotlinLibraryConventionPlugin.kt      (id: com.mygomii.kotlin.library)
+└─ example.md                # 이 문서
+```
+
+## 화면 및 주요 기능
+- 하단 탭바: ‘검색’, ‘즐겨찾기’
+- 상단 탭바(공통 TopAppBar): 라우트별 타이틀/액션
+
+1) 검색 리스트(탭1)
+- 검색: 상단 입력(제목/저자), 키보드 Search로 실행
+- 정렬: 정확도순/발간일 토글 (좌측 현재 정렬 텍스트, 우측 정렬 아이콘)
+- 필터: 최소/최대 가격, 출판사 (토글형 패널)
+- 목록: 카드형(썸네일, 제목, 출판사, 저자, 가격), 즐겨찾기 하트
+- 페이징: 20개씩 ‘더 보기’
+
+2) 즐겨찾기(탭2)
+- 검색: 제목/저자 로컬 검색
+- 정렬: ‘오늘추가’(최근 추가) / ‘제목’ 토글 (상단 텍스트+정렬 아이콘)
+- 필터: 최소/최대 가격, 출판사
+- 목록: 카드형, 하트 해제 시 즉시 제거
+
+3) 상세(탭3)
+- 상단 탭바: 뒤로가기, 하트(저장/해제)
+- 본문: 제목 → (좌 표지 / 우 정보: 저자/출판사/출간일/ISBN/가격) → 책 소개(스크롤)
+
+## 데이터/아키텍처 개요
+- Domain
+  - `BookRepository`: 추상화된 인터페이스
+  - UseCase: `SearchBooks`, `ToggleFavorite`, `ObserveFavorites`
+- Data
+  - Remote: `KakaoBookApi`(Ktor), Kakao DTO → Domain 매핑
+  - Local: Room `AppDatabase`/`BookDao`/`FavoriteBookEntity(addedAt)`
+  - Impl: `BookRepositoryImpl`에서 원격 검색 + 로컬 즐겨찾기 제공
+- Presentation
+  - Compose + ViewModel 상태(Flow/StateFlow)
+  - 공통 TopAppBar: 라우트별 타이틀/상태/액션
+  - Coil로 이미지 처리(플레이스홀더 포함)
+
+## 외부 API
+- Kakao Developers – 도서 검색 API
+- 엔드포인트: `GET https://dapi.kakao.com/v3/search/book`
+- 헤더: `Authorization: KakaoAK {REST_API_KEY}`
+- 주요 파라미터: `query`, `sort=accuracy|recency`, `page`, `size`, `target=title|person` 등
+
+## 구성/환경 주입
+- API 키 주입: `local.properties` → `BuildConfig.KAKAO_API_KEY`로 주입
+- Service Locator
+  - Room DB(`books.db`) + `KakaoBookApi`로 `BookRepositoryImpl` 구성
+  - 추후 Hilt/Koin DI로 전환 용이
+
+## 빌드 로직(build-logic)
+- 공통 컨벤션 플러그인으로 compileSdk/minSdk/targetSdk, JVM Toolchain(17), Compose, BuildConfig 설정 중앙화
+- 라이브러리 모듈 기본 Compose 비활성 → 필요한 모듈(presentation 등)에서만 compose 플러그인/feature 활성화
+
+## 접근성/UX
+- 터치 타겟/텍스트 계층/대비 고려(추가 튜닝 여지 있음)
+- 썸네일 미존재 시 기본 이미지 제공
+- 가격 표기 일관: `#,###원`
+
+## 한계/향후 개선
+- 네비게이션: 간단화를 위해 선택 항목은 임시 Holder 사용 → Nav Arg/Serializable 모델로 개선 권장
+- 에러/로딩 UI: 최소 구현 → 스낵바/리트라이 강화 가능
+- Paging3 미사용 → 필요 시 교체
+- 테스트: 유닛/스냅샷/UiTest 추가 가능
+- 정렬/필터 확장: 상세 조건(저자/ISBN 등) 추가 및 저장/복원
+
+## 라이선스
+- 샘플 용도. 내부/개인 학습 프로젝트로 사용 가능.

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,27 +1,12 @@
 plugins {
-    id("com.android.library")
-    alias(libs.plugins.kotlin.android)
+    id("com.mygomii.android.library")
     alias(libs.plugins.kotlin.compose)
 }
 
 android {
     namespace = "com.mygomii.booksearch.presentation"
     compileSdk = 36
-
-    defaultConfig {
-        minSdk = 24
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-    buildFeatures {
-        compose = true
-    }
+    buildFeatures { compose = true }
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,3 +24,6 @@ include(":app")
 include(":domain")
 include(":data")
 include(":presentation")
+
+// Include build-logic (convention plugins)
+includeBuild("build-logic")


### PR DESCRIPTION
…nd update README

This commit introduces convention plugins to simplify and standardize the Gradle build configuration across modules. It also significantly expands the README.md file with detailed project information.

Key changes:

-   **Gradle Convention Plugins**:
    -   Created `build-logic` module to house custom convention plugins:
        -   `com.mygomii.android.application`
        -   `com.mygomii.android.library`
        -   `com.mygomii.kotlin.library`
    -   Applied these plugins to `app`, `data`, `domain`, and `presentation` modules, removing redundant configurations (e.g., `compileSdk`, `minSdk`, `compileOptions`, `kotlinOptions`).
    -   Included `build-logic` in `settings.gradle.kts`.
-   **README.md**:
    -   Added comprehensive project overview, including:
        -   Main features (search, sort, filter, favorites, details, infinite scroll).
        -   Technology stack (Kotlin, Compose, Clean Architecture, Ktor, Room, Coil, etc.).
        -   Project structure diagram.
        -   Architecture overview (Clean Architecture, module dependencies).
        -   Build instructions (prerequisites, cloning, API key setup, build commands).
        -   Key implementation points (Clean Architecture, state management, networking, local DB, UI/UX).
        -   Data flow description.
        -   Testing command examples.
        -   Dependency management approach (Version Catalog).
-   **Module `build.gradle.kts` Updates**:
    -   `app`, `data`, `presentation`: Replaced `com.android.application`/`library` and `org.jetbrains.kotlin.android` plugins with the new convention plugins. Removed duplicated Android configurations.
    -   `domain`: Replaced `org.jetbrains.kotlin.jvm` plugin with `com.mygomii.kotlin.library` and removed Java toolchain/Kotlin JVM toolchain settings.
    -   Minor cleanup of comments in dependency blocks.